### PR TITLE
Make column width 100% for extra small screens

### DIFF
--- a/sass/utilities/_grid.scss
+++ b/sass/utilities/_grid.scss
@@ -39,6 +39,7 @@ $grid-type: float;//type of grid (either 'float' or 'flex' only)
 //Common properties of floated grid columns
 %grid-column-float{
   position: relative;
+  width: 100%;
   min-height: 1px; // Prevent columns from collapsing when empty
   padding-right: ($gutter-width / 2);
   padding-left: ($gutter-width / 2);
@@ -71,6 +72,7 @@ $grid-type: float;//type of grid (either 'float' or 'flex' only)
   @each $size-name, $container-width in $max-width{
     @include mq($size-name){
       .#{$container-name}{
+        width: 100%;
         max-width: map-get($max-width, $size-name);
       }
     }


### PR DESCRIPTION
- Make column width 100% for extra small screens